### PR TITLE
Fix post.html to show the home icon using current font-awesome

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,7 +5,7 @@ layout: default
 <p class="meta">
   {{ page.date | date: "%B %d, %Y" }} 
   <a href="/">
-    <i class="home icon-home"></i>
+    <i class="home fa fa-home"></i>
   </a>
 </p>
 


### PR DESCRIPTION
I think when you upgraded font-awesome you missed this change. The home icon in the top right corner of a post did not display.
