### PR TITLE
Sidebar markup tweaks

### DIFF
--- a/_includes/css/layout.css
+++ b/_includes/css/layout.css
@@ -24,7 +24,7 @@
 		font-size: 18px;
 	}
 
-	.sidebar ul {
+	#bio {
 		font-size: 14px;
 	}
 }

--- a/_includes/css/screen.css
+++ b/_includes/css/screen.css
@@ -107,11 +107,12 @@ nav h1, nav h2 {
   text-align: center;
 }
 
-nav hr {
+#bio {
   margin-top: 10px;
   margin-bottom: 15px;
   border: dotted #ddd;
-  border-width: 1px 0 0;
+  border-width: 1px 0;
+  padding-top: 15px;
 }
 
 #social {

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -4,17 +4,13 @@
     <img src="/logo.png" id="logo" alt="Blog logo"/>
   </a>
   <h2>I'm <a href="/">{{ site.data.theme.name }}</a>.</h2>
-  <hr/>
-  <ul>
-  <p>A brief bio or something witty.</p>
-  <p>
-    Edit me in <code>_includes/sidebar.html</code>
-  </p>
-  <hr/>
-  <div>
-    <div id="social">
-      {% include social.html %}
-    </div>
+  <div id="bio">
+    <p>A brief bio or something witty.</p>
+    <p>
+      Edit me in <code>_includes/sidebar.html</code>
+    </p>
   </div>
-  </ul>
+  <div id="social">
+    {% include social.html %}
+  </div>
 </nav>


### PR DESCRIPTION
Just some cleanup.

The `ul` in the sidebar didn't make semantic sense, and wasn't really contributing to styling. Replaced with a `div#bio` (open for discussion). Also removed the `hr`s (though I could keep a style rule for `.sidebar hr` for flexibility/backwards compatibility), adding borders on `div#bio` instead. And while I was at it, removed the wrapper `div` around `div#social`, which doesn't seem to serve any purpose.

Rendering shifts of a few px related to the margins on that `ul`.
