### PR TITLE
fix small typo

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -3,7 +3,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
  
- <title>The blog of {{ site.data..theme.name }}</title>
+ <title>The blog of {{ site.data.theme.name }}</title>
  <link href="{{ site.url }}/atom.xml" rel="self"/>
  <link href="{{ site.url }}"/>
  <updated>{{ site.time | date_to_xmlschema }}</updated>


### PR DESCRIPTION
I spotted a small typo in a Liquid tag in the atom feed (two dots). Didn't seem to affect the build, so it's an aesthetic fix.