### PR TITLE
Add a toggle in options to show atom feed in sidebar

### DIFF
--- a/_data/theme.yml
+++ b/_data/theme.yml
@@ -27,3 +27,6 @@ google_analytics_key: UA-xxxx-x
 
 # Toggle "Postings are my own" disclaimer in footer
 show_disclaimer: true
+
+# Toggle link/icon to view atom feed (/atom.xml) in sidebar
+show_atom_feed: true

--- a/_includes/social.html
+++ b/_includes/social.html
@@ -63,7 +63,9 @@ Follow me:
   </a>
   {% endif %}
 
+  {% if site.data.theme.show_atom_feed %}
   <a title="Atom feed" id="atom" href="/atom.xml">
     <i class="fa fa-rss-square"></i>
   </a>
+  {% endif %}
 </div>


### PR DESCRIPTION
#### What does this PR do?
- [x] Implements an option in settings to toggle the link/icon to the site's atom feed in the sidebar
