### PR TITLE
Updating year in footer automatically

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,6 +7,6 @@
   {% endif %}
 
   <p>
-    © {{ site.data.theme.name }}, 2014 &mdash; built with <a href="http://jekyllrb.com/">Jekyll</a> using <a href="https://github.com/swanson/lagom">Lagom theme</a>
+    © {{ site.data.theme.name }}, {{ 'now' | date: "%Y" }} &mdash; built with <a href="http://jekyllrb.com/">Jekyll</a> using <a href="https://github.com/swanson/lagom">Lagom theme</a>
   </p>
 </div>


### PR DESCRIPTION
It's a bit boring having to update the year on the footer whenever it changes. This change will make it so the year updates whenever you update the blog.